### PR TITLE
make template logo configurable, add allow hosts, fix report resolving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 # add later
 test_data/
 requirements.txt
+start.sh
+generate.sh

--- a/pheme/settings.py
+++ b/pheme/settings.py
@@ -33,8 +33,11 @@ import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
-TEMPLATE_PATH = BASE_DIR / 'template'
-
+STATIC_DIR = BASE_DIR / 'static'
+TEMPLATE_DIR = BASE_DIR / 'template'
+TEMPLATE_LOGO_ADDRESS = os.environ.get(
+    "TEMPLATE_LOGO_ADDRESS"
+) or 'file://{}/logo.jpg'.format(STATIC_DIR)
 DATA_UPLOAD_MAX_MEMORY_SIZE = None
 
 # Quick-start development settings - unsuitable for production
@@ -44,10 +47,10 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = None
 SECRET_KEY = 'aq^_++zzyd@q&7olh&huvyc=3v=h)y+muc75i9d6$l@4fewk)='
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
 
-ALLOWED_HOSTS = []
-
+ENV_HOSTS = os.environ.get("ALLOWED_HOSTS")
+DEBUG = False if ENV_HOSTS else True
+ALLOWED_HOSTS = ENV_HOSTS.split(' ') if ENV_HOSTS else []
 
 # Application definition
 
@@ -76,7 +79,7 @@ ROOT_URLCONF = 'pheme.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [TEMPLATE_PATH,],
+        'DIRS': [TEMPLATE_DIR,],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -122,10 +125,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
-
 STATICFILES_DIRS = [
-    BASE_DIR / 'static',
-    TEMPLATE_PATH,
+    STATIC_DIR,
+    TEMPLATE_DIR,
 ]
 
 # Logging

--- a/pheme/transformation/scanreport/gvmd.py
+++ b/pheme/transformation/scanreport/gvmd.py
@@ -138,7 +138,8 @@ def transform(
     data: Dict[str, str], group_by: Callable = group_by_host
 ) -> Report:
     report = data.pop("report")
-    report = report.pop("report")
+    # sometimes gvmd reports have .report.report sometimes just .report
+    report = report.pop("report", None) or report
     del data
     logger.info("data transformation; grouped by %s.", group_by)
 

--- a/pheme/transformation/scanreport/renderer.py
+++ b/pheme/transformation/scanreport/renderer.py
@@ -17,8 +17,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import logging
+from typing import Dict
 
 from django.template import loader
+from django.conf import settings
 from rest_framework import renderers
 from rest_framework.request import HttpRequest
 import pdfkit
@@ -33,6 +35,10 @@ class DetailScanReport(renderers.BaseRenderer):
             if request.GET.get('grouping') == 'host'
             else 'nvt_detailed_report.html'
         )
+
+    def _enrich(self, data: Dict) -> Dict:
+        data['logo'] = settings.TEMPLATE_LOGO_ADDRESS
+        return data
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         raise NotImplementedError(
@@ -49,7 +55,7 @@ class DetailScanHTMLReport(DetailScanReport):
         renderer_context = renderer_context or {}  # to throw key error
         request = renderer_context['request']
         template = self._template_based_on_request(request)
-        return loader.get_template(template).render(data)
+        return loader.get_template(template).render(self._enrich(data))
 
 
 class DetailScanPDFReport(DetailScanReport):
@@ -61,7 +67,7 @@ class DetailScanPDFReport(DetailScanReport):
         renderer_context = renderer_context or {}  # to throw key error
         request = renderer_context['request']
         template = self._template_based_on_request(request)
-        html = loader.get_template(template).render(data)
+        html = loader.get_template(template).render(self._enrich(data))
         logger.debug("created html")
         # workaround for https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4460
         pdf = pdfkit.from_string(

--- a/template/host_detailed_report.html
+++ b/template/host_detailed_report.html
@@ -49,7 +49,7 @@
         {% for scan in results.scans %}
         <div id="report_header">
             <div id="header_left">
-                <img class="auto_width" src="/tmp/logo.jpg" alt="logo">
+                <img class="auto_width" src="{{ logo }}" alt="logo">
             </div>
             <div id="header_center">
                 <h1 id=report_title>{{ title|default:"detailed scanreport" }}</h1>

--- a/tests/test_gvmd_scanreport_datatransformation.py
+++ b/tests/test_gvmd_scanreport_datatransformation.py
@@ -31,11 +31,12 @@ from tests.generate_test_data import gen_report
 oids = [uuid.uuid1().hex for _ in range(5)]
 hosts = ['first', 'second']
 
+
 @pytest.mark.parametrize(
     "scan_result", [gen_report(hosts, oids, with_optional=True)]
 )
 def test_group_by_nvt(scan_result):
-    data = {'report': {'report': scan_result}}
+    data = {'report': scan_result}
     result = transform(data, group_by=group_by_nvt)
     assert len(result.results.scans) == len(oids)
 


### PR DESCRIPTION
the logo in host_detailed_report.html is configurable via settings.py

the allowed hosts in settings.py can be overriden via env parameter

gvmd sometimes sends report[report[data]] and sometimes report[data] to
reflect that gvmd does check if report[report is there if so use
report[report else report

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
