### PR TITLE
make basepath configureable

### DIFF
--- a/pheme/settings.py
+++ b/pheme/settings.py
@@ -32,7 +32,12 @@ from pathlib import Path
 import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
+__configured_base = os.environ.get('PHEME_BASE_PATH')
+BASE_DIR = (
+    Path(__configured_base)
+    if __configured_base
+    else Path(__file__).resolve(strict=True).parent.parent
+)
 STATIC_DIR = BASE_DIR / 'static'
 TEMPLATE_DIR = BASE_DIR / 'template'
 PARAMETER_FILE_ADDRESS = os.environ.get(


### PR DESCRIPTION
**What**:
Make basepath configurable
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
So the defaults can be used even though pheme got installed and started via pip

<!-- Why are these changes necessary? -->

**How**:
start pheme with a different BASE_PATH and see if the contents are reachable via localhost:8000/static/a_name

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
