### PR TITLE
fix bug of missing path while load_params when rendering

### DIFF
--- a/pheme/parameter.py
+++ b/pheme/parameter.py
@@ -16,7 +16,7 @@ from pheme import settings
 from pheme.authentication import SimpleApiKeyAuthentication
 
 
-def load_params(from_path: str = None) -> Dict:
+def load_params(from_path: str = settings.PARAMETER_FILE_ADDRESS) -> Dict:
     param_file_obj = Path(from_path)
     return (
         json.loads(param_file_obj.read_text())


### PR DESCRIPTION
**What**:

While rendering pheme was unable to load the parameter due to missing from_path

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
