### PR TITLE
add xml render possibility to ignore overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ curl -H 'accept: text/markdown+table' localhost:8000/scanreport/data/description
 http://localhost:8000/static/report_format_editor.html
 ```
 - overridable design parameter [55](https://github.com/greenbone/pheme/pull/55)
+- add possibility to not include overview information to remove charts and redundant information [63](https://github.com/greenbone/pheme/pull/63)
+```
+curl 'http://localhost:8000/report/$ID_OF_PREVIOUS_POST?without_overview=TRUE' -H 'Accept: text/csv'
+```
+- add xml response [63](https://github.com/greenbone/pheme/pull/63)
+```
+curl 'http://localhost:8000/report/$ID_OF_PREVIOUS_POST' -H 'Accept: application/xml'
+```
+- add csv response [63](https://github.com/greenbone/pheme/pull/63)
+```
+curl 'http://localhost:8000/report/$ID_OF_PREVIOUS_POST' -H 'Accept: text/csv'
+```
 ### Changed
 ### Deprecated
 ### Removed

--- a/pheme/views.py
+++ b/pheme/views.py
@@ -26,7 +26,7 @@ from rest_framework.request import Request
 from pheme.parser.xml import XMLFormParser, XMLParser
 from pheme.transformation import scanreport
 from pheme.storage import store, load
-from pheme.renderer import MarkDownTableRenderer, XMLRenderer
+from pheme.renderer import MarkDownTableRenderer, XMLRenderer, CSVRenderer
 from pheme.transformation.scanreport import model
 
 
@@ -116,6 +116,7 @@ def template_elements(request: Request, name: str):
         scanreport.renderer.DetailScanHTMLReport,
         scanreport.renderer.DetailScanPDFReport,
         XMLRenderer,
+        CSVRenderer,
     ]
 )
 def report(request: Request, name: str):

--- a/pheme/views.py
+++ b/pheme/views.py
@@ -26,7 +26,7 @@ from rest_framework.request import Request
 from pheme.parser.xml import XMLFormParser, XMLParser
 from pheme.transformation import scanreport
 from pheme.storage import store, load
-from pheme.renderer import MarkDownTableRenderer
+from pheme.renderer import MarkDownTableRenderer, XMLRenderer
 from pheme.transformation.scanreport import model
 
 
@@ -115,6 +115,7 @@ def template_elements(request: Request, name: str):
         scanreport.renderer.ReportFormatHTMLReport,
         scanreport.renderer.DetailScanHTMLReport,
         scanreport.renderer.DetailScanPDFReport,
+        XMLRenderer,
     ]
 )
 def report(request: Request, name: str):
@@ -133,7 +134,14 @@ def report(request: Request, name: str):
                 "images": images,
             }
         )
-    return Response(load(name))
+    data = load(name)
+    if request.GET.get('without_overview'):
+        # remove charts
+        data.pop('overview', None)
+    if request.META.get('HTTP_ACCEPT') == "application/xml":
+        # XML needs exactly one root
+        data = {'report': data}
+    return Response(data)
 
 
 @api_view(['GET'])

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -56,6 +56,7 @@ def test_report_contains_charts():
         "application/xml",
         "application/pdf",
         "text/html",
+        "text/csv",
     ],
 )
 def test_http_accept(http_accept):

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -19,6 +19,7 @@
 
 from typing import List
 
+import pytest
 from django.core.cache import cache
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -46,6 +47,35 @@ def test_report_contains_charts():
     assert result['overview']['hosts'] is not None
     assert result['overview']['nvts'] is not None
     assert result['overview']['vulnerable_equipment'] is not None
+
+
+@pytest.mark.parametrize(
+    "http_accept",
+    [
+        "application/json",
+        "application/xml",
+        "application/pdf",
+        "text/html",
+    ],
+)
+def test_http_accept(http_accept):
+    url = reverse('transform')
+    report = {
+        'report': {
+            'report': gen_report(
+                generate('host', 1),
+                generate('oid', 1),
+                name='http_accept_test',
+            )
+        }
+    }
+    client = APIClient()
+    response = client.post(url, data=report, format='xml')
+    assert response.status_code == 200
+    key = response.data
+    report_url = reverse('report', kwargs={'name': key})
+    html_report = client.get(report_url, HTTP_ACCEPT=http_accept)
+    assert html_report.status_code == 200
 
 
 def test_generate_format_editor_html_report():


### PR DESCRIPTION
**What**:
Add xml as well as csv report response. Add possibility to not include overview information.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

- upload a scanreport
- call:
curl -H "accept: application/xml" -o /tmp/test.xml http://localhost:8000/report/$ID?without_overview=true
curl -H "accept: text/csv" -o /tmp/test.csv http://localhost:8000/report/$ID?without_overview=true

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
