### PR TITLE
add possibility to merge json dict into global parameter

### DIFF
--- a/pheme/parameter.py
+++ b/pheme/parameter.py
@@ -64,14 +64,16 @@ def put_value(
 
 
 @api_view(['PUT'])
-@parser_classes([rest_framework.parsers.MultiPartParser])
+@parser_classes(
+    [rest_framework.parsers.JSONParser, rest_framework.parsers.MultiPartParser]
+)
 @renderer_classes(
     [
         rest_framework.renderers.JSONRenderer,
     ]
 )
 @authentication_classes([SimpleApiKeyAuthentication])
-def put_file(request: Request) -> Response:
+def put(request: Request) -> Response:
     def manipulate(data: Dict) -> Dict:
         for (key, value) in request.data.items():
             if isinstance(value, UploadedFile):
@@ -87,4 +89,9 @@ def put_file(request: Request) -> Response:
                 data[key] = value
         return data
 
+    def merge(data: Dict) -> Dict:
+        return {**data, **request.data}
+
+    if request.content_type == "application/json":
+        return __put(merge)
     return __put(manipulate)

--- a/pheme/urls.py
+++ b/pheme/urls.py
@@ -47,8 +47,8 @@ urlpatterns = [
     ),
     path(
         'parameter',
-        pheme.parameter.put_file,
-        name='put_file_parameter',
+        pheme.parameter.put,
+        name='put_parameter',
     ),
     path('cache/<str:key>', pheme.views.load_cache, name='load_cache'),
     path('cache', pheme.views.store_cache, name='store_cache'),

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -13,7 +13,7 @@ def test_unauthorized_on_missing_x_api_key():
     )
     response = client.put(url, data="#66c430", format='json')
     assert response.status_code == 403
-    url = reverse('put_file_parameter')
+    url = reverse('put_parameter')
     response = client.put(url, data={})
     assert response.status_code == 403
 
@@ -23,7 +23,7 @@ def test_put_image(upload_file):
     upload_file.name = 'test.svg'
     client = APIClient()
     url = reverse(
-        'put_file_parameter',
+        'put_parameter',
     )
     # api_key = request.META.get('HTTP_X_API_KEY', "")
     response = client.put(
@@ -42,7 +42,7 @@ def test_not_allow_binary_types(upload_file):
     upload_file.name = 'test.pdf'
     client = APIClient()
     url = reverse(
-        'put_file_parameter',
+        'put_parameter',
     )
     # api_key = request.META.get('HTTP_X_API_KEY', "")
     with pytest.raises(ValueError):
@@ -53,6 +53,34 @@ def test_not_allow_binary_types(upload_file):
                 "cover_image": upload_file,
             },
             HTTP_X_API_KEY=SECRET_KEY,
+        )
+
+
+def test_put_merge_json():
+    client = APIClient()
+    url = reverse(
+        'put_parameter',
+    )
+    # api_key = request.META.get('HTTP_X_API_KEY', "")
+    response = client.put(
+        url,
+        data={"main_color2": "#FFF"},
+        format='json',
+        HTTP_X_API_KEY=SECRET_KEY,
+    )
+    assert response.status_code == 200
+    assert response.data["main_color2"] == "#FFF"
+
+
+def test_put_not_merge_string_json():
+    client = APIClient()
+    url = reverse(
+        'put_parameter',
+    )
+    # api_key = request.META.get('HTTP_X_API_KEY', "")
+    with pytest.raises(TypeError):
+        assert client.put(
+            url, data="#66c430", format='json', HTTP_X_API_KEY=SECRET_KEY
         )
 
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -25,7 +25,6 @@ def test_put_image(upload_file):
     url = reverse(
         'put_parameter',
     )
-    # api_key = request.META.get('HTTP_X_API_KEY', "")
     response = client.put(
         url,
         data={
@@ -44,7 +43,6 @@ def test_not_allow_binary_types(upload_file):
     url = reverse(
         'put_parameter',
     )
-    # api_key = request.META.get('HTTP_X_API_KEY', "")
     with pytest.raises(ValueError):
         assert client.put(
             url,
@@ -61,7 +59,6 @@ def test_put_merge_json():
     url = reverse(
         'put_parameter',
     )
-    # api_key = request.META.get('HTTP_X_API_KEY', "")
     response = client.put(
         url,
         data={"main_color2": "#FFF"},
@@ -77,7 +74,6 @@ def test_put_not_merge_string_json():
     url = reverse(
         'put_parameter',
     )
-    # api_key = request.META.get('HTTP_X_API_KEY', "")
     with pytest.raises(TypeError):
         assert client.put(
             url, data="#66c430", format='json', HTTP_X_API_KEY=SECRET_KEY
@@ -90,7 +86,6 @@ def test_put_main_color():
         'put_value_parameters',
         kwargs={"key": "main_color"},
     )
-    # api_key = request.META.get('HTTP_X_API_KEY', "")
     response = client.put(
         url, data="#66c430", format='json', HTTP_X_API_KEY=SECRET_KEY
     )

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -61,7 +61,7 @@ def test_http_accept_visual(http_accept):
     template_key = 'vulnerability_report'
     client = APIClient()
     url = reverse(
-        'put_file_parameter',
+        'put_parameter',
     )
     # api_key = request.META.get('HTTP_X_API_KEY', "")
     response = client.put(


### PR DESCRIPTION
**What**:
Add a possibility to merge a json object into the global parameter.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

To make the transfer from developer parameter.json into report-formats easier.

<!-- Why are these changes necessary? -->

**How**:

```
curl -X PUT -H "content-type: application/json" localhost:8000/parameter\
         -d @path_to_json.json\
          -H 'x-api-key: SECRET_KEY_missing_using_default_not_suitable_in_production'
```
verify parameter json of your running pheme.


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
