### PR TITLE
Separate html and pdf template

### DIFF
--- a/pheme/parameter.py
+++ b/pheme/parameter.py
@@ -20,6 +20,8 @@ from pheme.authentication import SimpleApiKeyAuthentication
 
 logger = logging.getLogger(__name__)
 
+mimetypes.add_type('text/scss', '.scss')
+
 
 def load_params(from_path: str = settings.PARAMETER_FILE_ADDRESS) -> Dict:
     param_file_obj = Path(from_path)
@@ -78,10 +80,15 @@ def put(request: Request) -> Response:
         for (key, value) in request.data.items():
             if isinstance(value, UploadedFile):
                 file_type, _ = mimetypes.guess_type(value.name)
-                logger.info("uploaded %s for %s", file_type, key)
-                if file_type.startswith('image'):
+                logger.info(
+                    "uploading filetype %s/%s for %s",
+                    file_type,
+                    value.name,
+                    key,
+                )
+                if file_type and file_type.startswith('image'):
                     data[key] = filename_as_datalink(value.name, value.read())
-                elif file_type.startswith('text'):
+                elif file_type and file_type.startswith('text'):
                     data[key] = value.read().decode()
                 else:
                     raise ValueError("Only image or text is permitted")

--- a/pheme/transformation/scanreport/renderer.py
+++ b/pheme/transformation/scanreport/renderer.py
@@ -85,7 +85,7 @@ class Report(renderers.BaseRenderer):
 
 
 class VulnerabilityHTMLReport(Report):
-    __template = 'vulnerability_report_template'
+    __template = 'vulnerability_report_html_template'
     __css_template = 'vulnerability_report_html_css'
     media_type = 'text/html'
     format = 'html'
@@ -103,7 +103,7 @@ class VulnerabilityHTMLReport(Report):
 
 
 class VulnerabilityPDFReport(Report):
-    __template = 'vulnerability_report_template'
+    __template = 'vulnerability_report_pdf_template'
     __css_template = 'vulnerability_report_pdf_css'
     media_type = 'application/pdf'
     format = 'binary'

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -57,8 +57,9 @@ def test_report_contains_charts():
     ],
 )
 def test_http_accept_visual(http_accept):
-    css_key = 'vulnerability_report_{}_css'.format(http_accept.split('/')[-1])
-    template_key = 'vulnerability_report_template'
+    subtype = http_accept.split('/')[-1]
+    css_key = 'vulnerability_report_{}_css'.format(subtype)
+    template_key = 'vulnerability_report_{}_template'.format(subtype)
     client = APIClient()
     url = reverse(
         'put_parameter',


### PR DESCRIPTION
**What**:

Due to different requirements for html structure for pdf and html reports this commit separated those two templates to prevent too many if HTML, if PDF ...

Add `text/scss`as mimetype in parameter to allow form upload of sass.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
