### PR TITLE
adds a workaround for inline svg and WeasyPrint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - nvt threat information in host result [114](https://github.com/greenbone/pheme/pull/114)
 ### Changed
 - remove pandas due to too old debian version [112](https://github.com/greenbone/pheme/pull/112)
+- add workaround for svg in pdf with wasyprint [120](https://github.com/greenbone/pheme/pull/120)
+
 ### Deprecated
 ### Removed
 - libsass support: https://sass-lang.com/blog/libsass-is-deprecated [111](https://github.com/greenbone/pheme/pull/111)

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -26,6 +26,8 @@ from rest_framework.test import APIClient
 
 from pheme.datalink import as_datalink
 from pheme.settings import SECRET_KEY
+from pheme.transformation.scanreport import renderer
+
 from tests.generate_test_data import gen_report
 
 
@@ -63,6 +65,21 @@ def test_report_contains_charts():
     assert result['overview']['hosts'] is not None
     assert result['overview']['nvts'] is not None
     # assert result['overview']['vulnerable_equipment'] is not None
+
+
+@pytest.mark.parametrize(
+    "html_contains",
+    [
+        ('<svg width="343"><g id="severity_arrows">', "svg"),  # missing end tag
+        ('<svg width="343"><g id="severity_arrows"></svg>', "img"),  # replaced
+        ('<div width="343"><g id="severity_arrows"></div>', "div"),  # not svg
+    ],
+)
+def test_workaround_for_inline_svg_and_weasyprint(html_contains):
+    # pylint: disable=W0212
+    html, contains = html_contains
+    result = renderer._replace_inline_svg_with_img_tags(html)
+    assert contains in result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What**:

Unfortunately WeasyPrint does not support inline svg at all, since we
need that functionality to create pictures dynamically based on
report-formats.

This workaround does look for tags with svg and then creates an img
element with base64 image content of that.

We are painfully aware that we lose css information with that method,
but the conclusion is that it is better to may define design element twice
(in the svg and in css) than to not have this possibility at all.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

Create an pdf-report template with svg content in it. Create a pdf and verify that the svg is displayed.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
