### PR TITLE
add severity information into host overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - nvt threat information in host result [114](https://github.com/greenbone/pheme/pull/114)
+- nvt severity information in host result [114](https://github.com/greenbone/pheme/pull/121)
 ### Changed
 - remove pandas due to too old debian version [112](https://github.com/greenbone/pheme/pull/112)
 ### Deprecated

--- a/pheme/transformation/scanreport/model.py
+++ b/pheme/transformation/scanreport/model.py
@@ -112,6 +112,20 @@ def describe():
                     'total': 'int; amount of nvts in host',
                     'highest': 'str; highest threat within host',
                 },
+                severities={
+                    '1': 'int; amount of 1 severities in host',
+                    '2': 'int; amount of 2 severities in host',
+                    '3': 'int; amount of 3 severities in host',
+                    '4': 'int; amount of 4 severities in host',
+                    '5': 'int; amount of 5 severities in host',
+                    '6': 'int; amount of 6 severities in host',
+                    '7': 'int; amount of 7 severities in host',
+                    '8': 'int; amount of 8 severities in host',
+                    '9': 'int; amount of 9 severities in host',
+                    '10': 'int; amount of 10 severities in host',
+                    'total': 'int; amount of nvts in host',
+                    'highest': 'str; highest severity within host',
+                },
                 equipment=Equipment(
                     os="str; operating system", ports=["str; open ports"]
                 ),


### PR DESCRIPTION
In the vulnerabilty report there is the need to have severity
information easily accessable per host.

You can verify the severity information with a host result by uploading
an report and create a json representation of a report and then e.g.
with `jq '.results[0].severities' `.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
