### PR TITLE
add second path for default parameter

### DIFF
--- a/pheme/parameter.py
+++ b/pheme/parameter.py
@@ -21,13 +21,35 @@ import pheme.authentication
 logger = logging.getLogger(__name__)
 
 
-def load_params(from_path: str = settings.PARAMETER_FILE_ADDRESS) -> Dict:
+def __load_params(from_path: str) -> Dict:
+    """
+    either loads json file from given_path or returns an empty dict when file
+    does not exist.
+
+    """
     param_file_obj = Path(from_path)
     return (
         json.loads(param_file_obj.read_text())
         if param_file_obj.exists()
         else {}
     )
+
+
+def load_params(
+    system_parameter_path: str = settings.PARAMETER_FILE_ADDRESS,
+    default_parameter_path: str = settings.DEFAULT_PARAMETER_ADDRESS,
+) -> Dict:
+    """
+    loads default and system parameter and combines them so that system
+    parameter may override default parameter.
+
+    A system parameter is set and handled by an individual system while default
+    parameter usually come from data-objects.
+    """
+    return {
+        **__load_params(default_parameter_path),
+        **__load_params(system_parameter_path),
+    }
 
 
 def __store(params: Dict, *, from_path: str = None) -> Dict:
@@ -42,7 +64,7 @@ def __put(
     from_path: str = settings.PARAMETER_FILE_ADDRESS,
     store: Callable[[Dict, str], Dict] = __store
 ) -> Response:
-    params = load_params(from_path=from_path)
+    params = __load_params(from_path=from_path)
     username = request.META.get('GVM_USERNAME')
     if username:
         all_user = params.get('user_specific', {})

--- a/pheme/settings.py
+++ b/pheme/settings.py
@@ -40,9 +40,16 @@ BASE_DIR = (
 )
 STATIC_DIR = BASE_DIR / 'static'
 TEMPLATE_DIR = BASE_DIR / 'template'
+# set default to actual gos path instead of static dir
 PARAMETER_FILE_ADDRESS = os.environ.get(
     "PARAMETER_FILE_ADDRESS"
 ) or '//{}/parameter.json'.format(STATIC_DIR)
+
+DEFAULT_PARAMETER_ADDRESS = (
+    os.environ.get("DEFAULT_PARAMETER_FILE_ADDRESS")
+    or '/usr/local/var/lib/gvm/data-objects/21.04/pheme/default-parameter.json'
+)
+
 
 GSAD_URL = os.environ.get('GSAD_URL', "http://localhost:8080/gmp")
 


### PR DESCRIPTION
Due to the delivery method of data-objects it can happen that the
parameter.json will be overridden when the feed version has a newer date
than the system parameter.

For this case it is necessary to have two separated files, one for
system specific adaptations and one delivered via data-objects.

Therefor a new path variable DEFAULT_PARAMETER_ADDRESS is introduced.
When loading parameter the two parameter will be combined in a way that
the system parameter json may override the default parameter.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
