### PR TITLE
add possibility to use dynamic_template within parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - nvt threat information in host result [114](https://github.com/greenbone/pheme/pull/114)
 - nvt severity information in host result [121](https://github.com/greenbone/pheme/pull/121)
 - treemap as svg [128](https://github.com/greenbone/pheme/pull/128)
+- dynamic template functionality [139](https://github.com/greenbone/pheme/pull/139/files)
 ### Changed
 - remove pandas due to too old debian version [112](https://github.com/greenbone/pheme/pull/112)
 - add workaround for svg in pdf with wasyprint [120](https://github.com/greenbone/pheme/pull/120)

--- a/pheme/settings.py
+++ b/pheme/settings.py
@@ -58,10 +58,11 @@ PHEME_CONFIGURATION_PATH = Path(
 SECRET_KEY_LOCATION = PHEME_CONFIGURATION_PATH.joinpath('api_key')
 
 PARAMETER_FILE_ADDRESS = PHEME_CONFIGURATION_PATH.joinpath('parameter.json')
-
+DATA_OBJECT_PATH = "/usr/local/var/lib/gvm/data-objects/gvmd"
+GOS_VERSION = "21.04"
 DEFAULT_PARAMETER_ADDRESS = (
     os.environ.get("DEFAULT_PARAMETER_FILE_ADDRESS")
-    or '/usr/local/var/lib/gvm/data-objects/gvmd/21.04/pheme/default-parameter.json'
+    or f'{DATA_OBJECT_PATH}/{GOS_VERSION}/pheme/default-parameter.json'
 )
 
 

--- a/pheme/templatetags/dynamic_template.py
+++ b/pheme/templatetags/dynamic_template.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# pheme/templatetags/dynamic_template.py
+# Copyright (C) 2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Adds the possibility to dynamially render template snippets load via parameter
+and render them into another template without having the need to declare them
+as a dependency upfront.
+"""
+
+from django.utils.safestring import mark_safe, SafeString
+from django import template
+from pheme.parameter import load_params
+
+
+register = template.Library()
+
+
+@register.filter
+def dynamic_template(data, key: str) -> SafeString:
+    """
+    Loads the template via key and renders the template with the given
+    data.
+
+    Parameter:
+        data - used to create the context for the renderer
+        key: str - identifier of the template to render
+
+    Returns:
+        The rendered template or an empty string when the key is not found
+    """
+    tmpl = load_params().get(key)
+    if not tmpl:
+        return mark_safe("")
+    return mark_safe(template.Template(tmpl).render(template.Context(data)))

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -84,8 +84,8 @@ def test_workaround_for_inline_svg_and_weasyprint(html_contains):
 
 def test_dynamic_template():
     subtype = "html"
-    css_key = 'vulnerability_report_{}_css'.format(subtype)
-    template_key = 'vulnerability_report_{}_template'.format(subtype)
+    css_key = f'vulnerability_report_{subtype}_css'
+    template_key = f'vulnerability_report_{subtype}_template'
     client = APIClient()
     url = reverse(
         'put_parameter',

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -82,6 +82,39 @@ def test_workaround_for_inline_svg_and_weasyprint(html_contains):
     assert contains in result
 
 
+def test_dynamic_template():
+    subtype = "html"
+    css_key = 'vulnerability_report_{}_css'.format(subtype)
+    template_key = 'vulnerability_report_{}_template'.format(subtype)
+    client = APIClient()
+    url = reverse(
+        'put_parameter',
+    )
+    nvts_template = """
+    <h1>{{ High }}</h1>
+    """
+    render_charts = """
+    {% load dynamic_template %}
+    <html>
+    {{ overview.nvts | dynamic_template:"nvts_template" }}
+    </html>
+    """
+    response = client.put(
+        url,
+        data={
+            css_key: "html { background: #000; }",
+            'nvts_template': nvts_template,
+            template_key: render_charts,
+        },
+        HTTP_X_API_KEY=SECRET_KEY,
+    )
+    assert response.status_code == 200
+    response = test_http_accept("text/html")
+    nvts = response.data['overview']['nvts']
+    html_report = response.getvalue().decode('utf-8')
+    assert f"<h1>{nvts['High']}</h1>" in html_report
+
+
 def test_chart_keyswords():
     subtype = "html"
     css_key = 'vulnerability_report_{}_css'.format(subtype)


### PR DESCRIPTION
With `dynamic_template` it is possible to upload a template as parameter
and use it within an different template.

As an example when you upload a template with:
```
<h1>{{ High }}</h1>
```
and key `nvts_template`

When you then upload another template and want to use the previous
template within that you can load `dynamic_template` and use it like:

```
{% load dynamic_template %}
<html>
{{ overview.nvts | dynamic_template:"nvts_template" }}
</html>
```

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
