### PR TITLE
fix bug when report does not contain result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- settings to default to GOS settings [153](https://github.com/greenbone/pheme/pull/153)
 ### Deprecated
 ### Removed
 ### Fixed
+- division by zero when a report does not contain results [154](https://github.com/greenbone/pheme/pull/154)
 
 [Unreleased]: https://github.com/greenbone/pheme/compare/v21.04-rc1...HEAD
 

--- a/pheme/settings.py
+++ b/pheme/settings.py
@@ -187,7 +187,7 @@ LOGGING = {
         },
     },
     'root': {
-        'handlers': ['syslog'],
+        'handlers': ['syslog' if Path('/dev/log').exists() else 'console'],
         'level': os.getenv('DJANGO_LOG_LEVEL', 'INFO'),
     },
 }

--- a/pheme/templatetags/charts/h_bar.py
+++ b/pheme/templatetags/charts/h_bar.py
@@ -108,9 +108,10 @@ def h_bar_chart(
         title_color = _severity_class_colors
     max_width = svg_width - 175 - 100  # key and total placeholder
     # highest sum of counts
+    if not data.values():
+        return mark_safe("")
     max_sum = max([sum(list(counts.values())) for counts in data.values()])
-    if max_sum == 0:
-        return None
+
     orientation_lines = ""
     orientation_labels = ""
 

--- a/pheme/templatetags/charts/pie.py
+++ b/pheme/templatetags/charts/pie.py
@@ -75,6 +75,8 @@ def pie_chart(
     if not title_color:
         title_color = _severity_class_colors
     total = sum(input_values.values())
+    if total == 0:
+        return SafeText("")
     # pylint: disable=C0103
     # we start at 12' o clock
     angle_offset = -90


### PR DESCRIPTION
When a report does not contain a result than total was zero on a pie
chart which lead to division by zero. Fix is to return no diagram when
there are no results.

Also adds a changelog entry and fix for logs when there is no /dev/log mainly for docker.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
