### PR TITLE
Add font-family and size to text elements within charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- font-family and font-size to charts []()
+- font-family and font-size to charts [167](https://github.com/greenbone/pheme/pull/167)
 ### Changed
-- replaced hardcoded 175 in favor of max len hostname * font size * 1.25 in bar chart []()
+- replaced hardcoded 175 in favor of max len hostname * font size * 1.25 in bar chart [167](https://github.com/greenbone/pheme/pull/167)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- font-family and font-size to charts []()
 ### Changed
+- replaced hardcoded 175 in favor of max len hostname * font size * 1.25 in bar chart []()
 ### Deprecated
 ### Removed
 ### Fixed

--- a/pheme/templatetags/charts/__init__.py
+++ b/pheme/templatetags/charts/__init__.py
@@ -58,6 +58,8 @@ def _build_legend(
         font_size: size of used font, used to calculate x position of an element
         label_color: key is used as a label and the value as a fill color for an
             rectangle (font_size * font_size).
+        font_family - the font family used within text elements
+        font_size - the font size used within text elements
     Returns:
         A complete g element with legends as a string.
 

--- a/pheme/templatetags/charts/__init__.py
+++ b/pheme/templatetags/charts/__init__.py
@@ -20,9 +20,9 @@ from typing import Dict
 from django import template
 
 _severity_class_colors = {
-    'High': "#d4003e",
-    'Medium': "#fcb900",
-    'Low': "#7db4d0",
+    "High": "#d4003e",
+    "Medium": "#fcb900",
+    "Low": "#7db4d0",
 }
 
 register = template.Library()
@@ -34,12 +34,16 @@ __LEGEND_TEMPLATE = """
 """
 __LEGEND_ELEMENT = """
 <rect x="{x}" y="0" height="{font_size}" width="{font_size}" style="fill: {color};"></rect>
-<text x="{text_x}" y="{half_font_size}" dominant-baseline="central">{label}</text>
+<text style="font-size:{font_size};font-family:{font_family}" x="{text_x}" y="{half_font_size}" dominant-baseline="central">{label}</text>
 """
 
 
 def _build_legend(
-    start_height: int, width: int, font_size: int, label_color: Dict
+    start_height: int,
+    width: int,
+    label_color: Dict,
+    font_family: str = "Droid Sans",
+    font_size: int = 10,
 ) -> str:
     """
     Generates a legend at     start_height y position and at
@@ -65,6 +69,7 @@ def _build_legend(
         legend_elements += __LEGEND_ELEMENT.format(
             x=x_pos,
             font_size=font_size,
+            font_family=font_family,
             color=color,
             half_font_size=font_size / 2,
             label=label,

--- a/pheme/templatetags/charts/h_bar.py
+++ b/pheme/templatetags/charts/h_bar.py
@@ -43,9 +43,9 @@ __BAR_ELEMENT_TEMPLATE = """
 __BAR_TEMPLATE = """
 <g class="entry" transform="translate(0, {y})">
 <text class="label category" y="22" x="87.5" fill="#4C4C4D" dominant-baseline="central"
-style="font-size:{font_size};font-family:{font_family};text-anchor: right;" width="175">{key}
+style="font-size:{font_size};font-family:{font_family};text-anchor: right;" width="{max_hostname_len}">{key}
 </text>
-<g transform="translate(175, 0)">
+<g transform="translate({max_hostname_len}, 0)">
 {orientation_lines}
 {bar_elements}
 </g>
@@ -58,7 +58,7 @@ style="font-size:{font_size};font-family:{font_family};text-anchor: left;" width
 __BAR_CHART_TEMPLATE = """
 <svg width="{width}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">
 {bars}
-<g transform="translate(175, {bar_legend_y})">
+<g transform="translate({max_hostname_len}, {bar_legend_y})">
 {bar_legend}
 </g>
 {legend}
@@ -103,17 +103,20 @@ def h_bar_chart(
         orientation_basis - if higher than 0 than there will be a vertical line
             each orientation_basis.
         limit - limits the data by N first elements
+        font_family - the font family used within text elements
+        font_size - the font size used within text elements
     """
 
     data = dict(itertools.islice(chart_data.items(), limit))
     if not title_color:
         title_color = _severity_class_colors
-    max_width = svg_width - 175 - 100  # key and total placeholder
-    # highest sum of counts
     if not data.values():
         return SafeText("")
+    # multiply by 1.25 for kerning
+    max_hostname_len = max(len(k) for k in data.keys()) * font_size * 1.25
+    max_width = svg_width - max_hostname_len - 100  # key and total placeholder
+    # highest sum of counts
     max_sum = max([sum(list(counts.values())) for counts in data.values()])
-
     orientation_lines = ""
     orientation_labels = ""
 
@@ -160,6 +163,7 @@ def h_bar_chart(
                 color=color,
                 font_family=font_family,
                 font_size=font_size,
+                max_hostname_len=max_hostname_len,
             )
             element_x += width
 
@@ -171,6 +175,7 @@ def h_bar_chart(
             total=sum(counts.values()),
             font_family=font_family,
             font_size=font_size,
+            max_hostname_len=max_hostname_len,
         )
     svg_element_lengths = len(data.keys()) * bar_jump + 50
     svg_chart = __BAR_CHART_TEMPLATE.format(
@@ -182,5 +187,6 @@ def h_bar_chart(
         legend=_build_legend(svg_element_lengths + 10, svg_width, title_color),
         font_family=font_family,
         font_size=font_size,
+        max_hostname_len=max_hostname_len,
     )
     return SafeText(svg_chart)

--- a/pheme/templatetags/charts/pie.py
+++ b/pheme/templatetags/charts/pie.py
@@ -70,6 +70,8 @@ def pie_chart(
         chart_size: int the height and width of the
         border_size: int size of the border of slice
         slice_width: int the width of slice
+        font_family - the font family used within text elements
+        font_size - the font size used within text elements
 
     Returns:
     A SafeString with SVG

--- a/pheme/templatetags/charts/pie.py
+++ b/pheme/templatetags/charts/pie.py
@@ -35,7 +35,7 @@ __PIE_CHART_TEMPLATE = """
 __SLICE_TEMPLATE = """
 <g>
 <circle cx="{cx}" cy="{cy}" r="{radius}" stroke="{color}" stroke-width="{stroke_width}" stroke-dasharray="{d_array}" stroke-dashoffset="{s_offset}" transform="rotate({r_start}, {cx}, {cy})" fill="transparent"></circle>
-<text x="{t_x}" y="{t_y}" text-anchor="middle">{label}</text>
+<text style="font-size:{font_size};font-family:{font_family}" x="{t_x}" y="{t_y}" text-anchor="middle">{label}</text>
 </g>
 """
 
@@ -46,7 +46,9 @@ def pie_chart(
     title_color: Dict = None,
     chart_size: int = 320,
     border_size: int = 0,
-    slice_width: int = 60,
+    slice_width: int = 90,
+    font_family: str = "Droid Sans",
+    font_size: int = 10,
 ) -> SafeText:
     """
     creates a pie chart svg.
@@ -112,9 +114,11 @@ def pie_chart(
             t_x=t_x,
             t_y=t_y,
             label=f"{round(percent * 100)}%",
+            font_family=font_family,
+            font_size=font_size,
         ).strip()
 
-    legend = _build_legend(chart_size + 10, chart_size, 16, title_color)
+    legend = _build_legend(chart_size + 10, chart_size, title_color)
     return SafeText(
         __PIE_CHART_TEMPLATE.format(
             size=chart_size, height=chart_size + 26, donut=donut, legend=legend

--- a/pheme/templatetags/charts/treemap.py
+++ b/pheme/templatetags/charts/treemap.py
@@ -262,10 +262,11 @@ def treemap(
         data: needs to be an dict containing label, color_key and values.
         width: width of the svg (default 1024)
         height: height of the svg (default 768)
-        font_size: used font_size (default 11)
         border_color: color of the rectangle border (default white)
         title_color: the color_key to color lookup map
             (default _severity_class_colors)
+        font_family - the font family used within text elements
+        font_size - the font size used within text elements
 
     Returns:
         the treemap in svg as a SafeString.

--- a/poetry.lock
+++ b/poetry.lock
@@ -584,7 +584,7 @@ pytest = ">=2.6.0"
 
 [[package]]
 name = "pytz"
-version = "2020.5"
+version = "2021.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -1024,39 +1024,20 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [
@@ -1079,25 +1060,21 @@ pillow = [
     {file = "Pillow-8.1.0-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:d355502dce85ade85a2511b40b4c61a128902f246504f7de29bbeec1ae27933a"},
     {file = "Pillow-8.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:93a473b53cc6e0b3ce6bf51b1b95b7b1e7e6084be3a07e40f79b42e83503fbf2"},
     {file = "Pillow-8.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2353834b2c49b95e1313fb34edf18fca4d57446675d05298bb694bca4b194174"},
-    {file = "Pillow-8.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:1d208e670abfeb41b6143537a681299ef86e92d2a3dac299d3cd6830d5c7bded"},
     {file = "Pillow-8.1.0-cp36-cp36m-win32.whl", hash = "sha256:dd9eef866c70d2cbbea1ae58134eaffda0d4bfea403025f4db6859724b18ab3d"},
     {file = "Pillow-8.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:b09e10ec453de97f9a23a5aa5e30b334195e8d2ddd1ce76cc32e52ba63c8b31d"},
     {file = "Pillow-8.1.0-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:b02a0b9f332086657852b1f7cb380f6a42403a6d9c42a4c34a561aa4530d5234"},
     {file = "Pillow-8.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ca20739e303254287138234485579b28cb0d524401f83d5129b5ff9d606cb0a8"},
     {file = "Pillow-8.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:604815c55fd92e735f9738f65dabf4edc3e79f88541c221d292faec1904a4b17"},
-    {file = "Pillow-8.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cf6e33d92b1526190a1de904df21663c46a456758c0424e4f947ae9aa6088bf7"},
     {file = "Pillow-8.1.0-cp37-cp37m-win32.whl", hash = "sha256:47c0d93ee9c8b181f353dbead6530b26980fe4f5485aa18be8f1fd3c3cbc685e"},
     {file = "Pillow-8.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:96d4dc103d1a0fa6d47c6c55a47de5f5dafd5ef0114fa10c85a1fd8e0216284b"},
     {file = "Pillow-8.1.0-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:7916cbc94f1c6b1301ac04510d0881b9e9feb20ae34094d3615a8a7c3db0dcc0"},
     {file = "Pillow-8.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3de6b2ee4f78c6b3d89d184ade5d8fa68af0848f9b6b6da2b9ab7943ec46971a"},
     {file = "Pillow-8.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cdbbe7dff4a677fb555a54f9bc0450f2a21a93c5ba2b44e09e54fcb72d2bd13d"},
-    {file = "Pillow-8.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f50e7a98b0453f39000619d845be8b06e611e56ee6e8186f7f60c3b1e2f0feae"},
     {file = "Pillow-8.1.0-cp38-cp38-win32.whl", hash = "sha256:cb192176b477d49b0a327b2a5a4979552b7a58cd42037034316b8018ac3ebb59"},
     {file = "Pillow-8.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:6c5275bd82711cd3dcd0af8ce0bb99113ae8911fc2952805f1d012de7d600a4c"},
     {file = "Pillow-8.1.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:165c88bc9d8dba670110c689e3cc5c71dbe4bfb984ffa7cbebf1fac9554071d6"},
     {file = "Pillow-8.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:5e2fe3bb2363b862671eba632537cd3a823847db4d98be95690b7e382f3d6378"},
     {file = "Pillow-8.1.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7612520e5e1a371d77e1d1ca3a3ee6227eef00d0a9cddb4ef7ecb0b7396eddf7"},
-    {file = "Pillow-8.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d673c4990acd016229a5c1c4ee8a9e6d8f481b27ade5fc3d95938697fa443ce0"},
     {file = "Pillow-8.1.0-cp39-cp39-win32.whl", hash = "sha256:dc577f4cfdda354db3ae37a572428a90ffdbe4e51eda7849bf442fb803f09c9b"},
     {file = "Pillow-8.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:22d070ca2e60c99929ef274cfced04294d2368193e935c5d6febfd8b601bf865"},
     {file = "Pillow-8.1.0-pp36-pypy36_pp73-macosx_10_10_x86_64.whl", hash = "sha256:a3d3e086474ef12ef13d42e5f9b7bbf09d39cf6bd4940f982263d6954b13f6a9"},
@@ -1161,8 +1138,8 @@ pytest-env = [
     {file = "pytest-env-0.6.2.tar.gz", hash = "sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"},
 ]
 pytz = [
-    {file = "pytz-2020.5-py2.py3-none-any.whl", hash = "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"},
-    {file = "pytz-2020.5.tar.gz", hash = "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"},
+    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
+    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},


### PR DESCRIPTION
**What**:

Add font-family and size to text elements of charts and set the default values of those to 'Droid Sans' and 10.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

To reflect the charts within the mockup vision as good as possible.

Although there is CHANGELOG entry there are no unit tests for it, mainly because font changes are purely visual without a technical impact.
<!-- Why are these changes necessary? -->

**How**:

Create a PDF and verify that the font is smaller than on a previous version within the charts.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [X] Documentation
