### PR TITLE
Add functionality to transform iso datetime to human readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Possibility to transform '%Y-%m-%dT%H:%M:%S%z' into '%a, %b %d, %Y %I %p %Z' within a template [193](https://github.com/greenbone/pheme/pull/193)
 ### Changed
 - Orientation marker in bar charts are configured as a amount of lines instead of every amount draw a line [186](https://github.com/greenbone/pheme/pull/186)
 ### Deprecated

--- a/pheme/templatetags/readable_timeformat.py
+++ b/pheme/templatetags/readable_timeformat.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# pheme/templatetags/dynamic_template.py
+# Copyright (C) 2020-2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Adds the possibility to print iso_8601 strings as %a, %b %d, %Y %I %p %Z', e.g.:
+    2001-07-22T09:15:37Z -> Sun, Jul 22, 2001 09 AM UTC
+"""
+from datetime import datetime
+from django.utils.safestring import SafeText, SafeString
+from django import template
+
+
+register = template.Library()
+
+
+@register.filter
+def format_time(iso_8601: str) -> SafeString:
+    """
+    Transforms iso string to %a, %b %d, %Y %I %p %Z.
+
+    Parameter:
+        iso_8601 - the string to format
+
+    Returns:
+        An the input parameter on failure or an transformed SafeString with
+        human readable time format.
+    """
+
+    try:
+        time = datetime.strptime(iso_8601, "%Y-%m-%dT%H:%M:%S%z")
+        return SafeText(datetime.strftime(time, "%a, %b %d, %Y %I %p %Z"))
+    except ValueError:
+        return SafeText(iso_8601)

--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -182,9 +182,7 @@ def gen_report(
 
     results = {
         "max": "{}".format(random.randint(1, 1000)) if with_optional else None,
-        "start": "{}".format(random.randint(0, 1000))
-        if with_optional
-        else None,
+        "start": "2018-01-01T00:00:00+01:00",
     }
     if hosts is not None:
         results["result"] = list(result)
@@ -200,7 +198,7 @@ def gen_report(
         "ssl_certs": gen_count() if with_optional else None,
         "task": gen_task(name) if with_optional else None,
         "timestamp": "2342" if with_optional else None,
-        "scan_start": "2020-07-01T21:00" if with_optional else None,
+        "scan_start": "2018-01-01T00:00:00+01:00" if with_optional else None,
         "timezone": "timezone_abbrev" if with_optional else None,
         "timezone_abbrev": "UTC" if with_optional else None,
         "scan_end": "2020-07-01T21:00" if with_optional else None,

--- a/tests/test_format_time.py
+++ b/tests/test_format_time.py
@@ -1,0 +1,33 @@
+from django.urls import reverse
+from rest_framework.test import APIClient
+from tests.test_report_generation import test_http_accept
+
+from pheme.settings import SECRET_KEY
+
+
+def test_format_time_within_template():
+    subtype = "html"
+    css_key = f"vulnerability_report_{subtype}_css"
+    template_key = f"vulnerability_report_{subtype}_template"
+    client = APIClient()
+    url = reverse(
+        "put_parameter",
+    )
+    render_charts = """
+    {% load readable_timeformat %}
+    <html>
+    {{ start | format_time }}
+    </html>
+    """
+    response = client.put(
+        url,
+        data={
+            css_key: "html { background: #000; }",
+            template_key: render_charts,
+        },
+        HTTP_X_API_KEY=SECRET_KEY,
+    )
+    assert response.status_code == 200
+    response = test_http_accept("text/html")
+    html_report = response.getvalue().decode("utf-8")
+    assert "Mon, Jan 01, 2018 12 AM UTC+01:00" in html_report


### PR DESCRIPTION
To standardize the presentation of date time within gsa and the report
format a template function 'format_time' is introduced.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
