### PR TITLE
Change host.severity from int to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Possibility to transform '%Y-%m-%dT%H:%M:%S%z' into '%a, %b %d, %Y %I %p %Z' within a template [193](https://github.com/greenbone/pheme/pull/193)
 ### Changed
 - Orientation marker in bar charts are configured as a amount of lines instead of every amount draw a line [186](https://github.com/greenbone/pheme/pull/186)
+- NVT severity in float instead of int [194](https://github.com/greenbone/pheme/pull/194)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/pheme/transformation/scanreport/gvmd.py
+++ b/pheme/transformation/scanreport/gvmd.py
@@ -90,7 +90,7 @@ def __return_highest_threat(threats: List[int]) -> str:
     return "NA"
 
 
-def __host_threat_overview(threat_count: List[int]) -> Dict:
+def __host_threat_overview(threat_count: Dict) -> Dict:
     """
     returns nvt statistics mostly used in the per host overview
     """
@@ -178,7 +178,7 @@ def __create_results_per_host(report: Dict) -> List[Dict]:
         nvt["nvt_tags_interpreted"] = __tansform_tags(nvt.get("nvt_tags", ""))
         nvt["nvt_refs_ref"] = __group_refs(nvt.get("nvt_refs", {}))
         qod = transform_key("qod", result.get("qod", {}))
-        severity = int(float(result.get("severity", "0.0")))
+        severity = float(result.get("severity", "0.0"))
         new_host_result = {
             "port": port,
             "threat": threat,
@@ -213,7 +213,7 @@ def __create_results_per_host(report: Dict) -> List[Dict]:
 
         # severity 1 to 10
         host_severities = host_severity_count.get(hostname, [0] * 10)
-        host_severities[severity - 1] += 1
+        host_severities[int(severity) - 1] += 1
         host_severity_count[hostname] = host_severities
 
         by_host[hostname] = {


### PR DESCRIPTION
The actual severity of a host should be a float not an int, every
processed value based of severity should be an int for easier handling
within the templates.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
