### PR TITLE
Remove API doc entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Or in this case personification of a service to generate reports.
 - [Installation](#installation)
   - [Requirements](#requirements)
 - [Development](#development)
-- [API overview](#api-overview)
 - [Maintainer](#maintainer)
 - [Contributing](#contributing)
 - [License](#license)
@@ -56,16 +55,6 @@ Afterwards activate the git hooks for auto-formatting and linting via
 Validate the activated git hooks by running
 
     poetry run autohooks check
-
-## API overview
-
-To get an overview of the API you can start this project
-
-```
-poetry run python manage.py runserver
-```
-
-and then go to [swagger](http://localhost:8000/docs/)
 
 ## Usage
 


### PR DESCRIPTION
swagger got removed a while ago while packging it for debian:stable due
to older django version. Unfortunately removing the swagger API in the
doc got not removed.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
