### PR TITLE
Extend bar chart with x titles, add bar chart as tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- title for the x axis summary [243](https://github.com/greenbone/pheme/pull/243)
 ### Changed
 ### Deprecated
 ### Removed

--- a/pheme/templatetags/charts/h_bar.py
+++ b/pheme/templatetags/charts/h_bar.py
@@ -59,6 +59,16 @@ style="font-size:{font_size}px;font-family:{font_family};text-anchor: left;" wid
 __BAR_CHART_TEMPLATE = """
 <svg width="{width}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg">
 {bars}
+<g transform="translate(0, {bar_legend_y})">
+<text 
+    class="label category" 
+    y="22" x="87.5" 
+    fill="#4C4C4D" dominant-baseline="central"
+    style="font-size:{font_size}px;font-family:{font_family};text-anchor: right;" 
+    width="{max_hostname_len}">
+    {x_title}
+    </text>
+</g>
 <g transform="translate({max_hostname_len}, {bar_legend_y})">
 {bar_legend}
 </g>
@@ -68,8 +78,10 @@ __BAR_CHART_TEMPLATE = """
 
 
 @register.filter
+@register.simple_tag
 def h_bar_chart(
     chart_data: Dict[str, Dict[str, int]],
+    x_title="",
     title_color=None,
     svg_width=800,
     bar_jump=44,
@@ -106,15 +118,17 @@ def h_bar_chart(
         limit - limits the data by N first elements
         font_family - the font family used within text elements
         font_size - the font size used within text elements
+        x_title - the titile of the x axis
     """
-
     data = dict(itertools.islice(chart_data.items(), limit))
     if not title_color:
         title_color = _severity_class_colors
     if not data.values():
         return SafeText("")
     # multiply by 1.25 for kerning
-    max_hostname_len = max(len(k) for k in data.keys()) * font_size * 1.25
+    max_hostname_len = (
+        max(max(len(k) for k in data.keys()), len(x_title)) * font_size * 1.25
+    )
     max_width = svg_width - max_hostname_len - 100  # key and total placeholder
     # highest sum of counts
     max_sum = max([sum(list(counts.values())) for counts in data.values()])
@@ -192,5 +206,6 @@ def h_bar_chart(
         font_family=font_family,
         font_size=font_size,
         max_hostname_len=max_hostname_len,
+        x_title=x_title,
     )
     return SafeText(svg_chart)

--- a/pheme/templatetags/charts/h_bar.py
+++ b/pheme/templatetags/charts/h_bar.py
@@ -81,7 +81,7 @@ __BAR_CHART_TEMPLATE = """
 @register.simple_tag
 def h_bar_chart(
     chart_data: Dict[str, Dict[str, int]],
-    x_title="",
+    x_title: str = "",
     title_color=None,
     svg_width=800,
     bar_jump=44,
@@ -118,7 +118,7 @@ def h_bar_chart(
         limit - limits the data by N first elements
         font_family - the font family used within text elements
         font_size - the font size used within text elements
-        x_title - the titile of the x axis
+        x_title - the title of the x axis
     """
     data = dict(itertools.islice(chart_data.items(), limit))
     if not title_color:

--- a/pheme/views.py
+++ b/pheme/views.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import re
 import dataclasses
 import rest_framework.renderers
 from rest_framework.decorators import api_view, parser_classes, renderer_classes
@@ -30,11 +29,6 @@ from pheme.storage import store, load
 from pheme.renderer import MarkDownTableRenderer, XMLRenderer, CSVRenderer
 from pheme.transformation.scanreport import model
 from pheme.version import __version__
-
-# __but_numbers is used to remove everything but numbers of version
-# so that it can be used within a template for fature toggling without
-# the need for introducing version verifying filter/tags
-__but_numbers = re.compile(r"[^\d]")
 
 
 @api_view(["GET"])
@@ -143,7 +137,7 @@ def report(request: Request, name: str):
             }
         )
     data = load(name)
-    data["pheme_version"] = int(__but_numbers.sub("", __version__))
+    data["pheme_version"] = int("".join(filter(str.isdigit, __version__)))
     if request.GET.get("without_overview"):
         # remove charts
         data.pop("overview", None)

--- a/pheme/views.py
+++ b/pheme/views.py
@@ -16,6 +16,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import re
 import dataclasses
 import rest_framework.renderers
 from rest_framework.decorators import api_view, parser_classes, renderer_classes
@@ -28,6 +29,12 @@ from pheme.transformation import scanreport
 from pheme.storage import store, load
 from pheme.renderer import MarkDownTableRenderer, XMLRenderer, CSVRenderer
 from pheme.transformation.scanreport import model
+from pheme.version import __version__
+
+# __but_numbers is used to remove everything but numbers of version
+# so that it can be used within a template for fature toggling without
+# the need for introducing version verifying filter/tags
+__but_numbers = re.compile(r"[^\d]")
 
 
 @api_view(["GET"])
@@ -136,6 +143,7 @@ def report(request: Request, name: str):
             }
         )
     data = load(name)
+    data["pheme_version"] = int(__but_numbers.sub("", __version__))
     if request.GET.get("without_overview"):
         # remove charts
         data.pop("overview", None)

--- a/tests/test_report_generation.py
+++ b/tests/test_report_generation.py
@@ -126,7 +126,7 @@ def test_charts_generation_on_zero_severity_report():
         generate("oid", 10, 0),
         name="http_accept_test",
     )
-    test_chart_keyword(report, 3)
+    test_chart_keyword(report)
 
 
 def test_charts_generation_on_zero_result_report():
@@ -138,7 +138,7 @@ def test_charts_generation_on_zero_result_report():
     test_chart_keyword(report, 1)
 
 
-def test_chart_keyword(report=None, expected=3):
+def test_chart_keyword(report=None, expected=4):
     subtype = "html"
     css_key = "vulnerability_report_{}_css".format(subtype)
     template_key = "vulnerability_report_{}_template".format(subtype)
@@ -151,6 +151,7 @@ def test_chart_keyword(report=None, expected=3):
     <html>
     {{ overview.nvts | pie_chart}}
     {{ overview.hosts | h_bar_chart  }}
+    {% h_bar_chart overview.hosts x_title="Vulnerabilitites" %}
     {{ overview.hosts | treemap  }}
     </html>
     """


### PR DESCRIPTION
Add possibility to add a title to the count numbers on the x-axis

To use the whole functionality of bar_h without having to specify every
parameter in order it is also registered as a simpletag instead of just
a filter.

This allows templates to use the chart by calling it:

```
{%  h_bar_chart overview.hosts x_title="Vulnerabilitites" %}
```

In addition to that there is also a new field called pheme_version with
just the numbers of set version.

This allows feature_toggles within the templates e.g.:

```
{% if pheme_version and pheme_version > 2144 %}
{%  h_bar_chart overview.hosts x_title="Vulnerabilitites" %}
{% else %}
{{ overview.hosts |  h_bar_chart }}
{% end %}
```

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pheme/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
