### PR TITLE
Changed the parameter GOS_VERSION from "21.04" to "21.10".

### DIFF
--- a/pheme/settings.py
+++ b/pheme/settings.py
@@ -79,7 +79,7 @@ SECRET_KEY_LOCATION = PHEME_CONFIGURATION_PATH.joinpath("api_key")
 
 PARAMETER_FILE_ADDRESS = PHEME_CONFIGURATION_PATH.joinpath("parameter.json")
 DATA_OBJECT_PATH = "/opt/greenbone/feed/gvmd"
-GOS_VERSION = "21.04"
+GOS_VERSION = "21.10"
 DEFAULT_PARAMETER_ADDRESS = (
     os.environ.get("DEFAULT_PARAMETER_FILE_ADDRESS")
     or f"{DATA_OBJECT_PATH}/{GOS_VERSION}/pheme/default-parameter.json"


### PR DESCRIPTION

**What**:
In GOS 21.10.0 the vulnerability reports where empty because the
path to the file "default-parameter.json" was wrong because of the
wrong value of the parameter GOS_VERSION. So it had to be changed.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This is a small bug-fix.
Addresses AP-1874
<!-- Why are these changes necessary? -->

**How**:
Regrettably I can not test, if it works on a GOS 21.10 system. The way I can
run the generation of vulnerability reports on my system is presumably different.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pheme/blob/main/CHANGELOG.md) Entry
- [ ] Documentation
