### PR TITLE
Fix: Container image builds by using bullseye as base

### DIFF
--- a/.docker/pheme.Dockerfile
+++ b/.docker/pheme.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim as builder
+FROM debian:bullseye-slim as builder
 
 COPY . /source
 
@@ -17,7 +17,7 @@ RUN python -m pip install --upgrade pip && \
 
 RUN rm -rf dist && poetry build -f wheel
 
-FROM debian:stable-slim
+FROM debian:bullseye-slim
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,7 +21,7 @@ jobs:
           images: greenbone/pheme
           labels: |
             org.opencontainers.image.vendor=Greenbone
-            org.opencontainers.image.base.name=debian/stable-slim
+            org.opencontainers.image.base.name=debian/bullseye-slim
           flavor: latest=false # no latest container tag for git tags
           tags: |
             # create container tag for git tags


### PR DESCRIPTION

## What
Container image builds by using bullseye as base

## Why
Using bullseye seems to be the better solution then to upgrade to bookworm and have to fiddle with the pip installations. Just keep the thing stable.