### PR TITLE
Added some extra space in the h_bar_chart (Top 10 Hosts graph) for the legend

### DIFF
--- a/pheme/templatetags/charts/h_bar.py
+++ b/pheme/templatetags/charts/h_bar.py
@@ -132,9 +132,10 @@ def h_bar_chart(
         title_color = _severity_class_colors
     if not data.values():
         return SafeText("")
-    # multiply by 1.25 for kerning
+    # multiply by 1.25 for kerning and add 87.5 for legend
     max_hostname_len = (
         max(max(len(k) for k in data.keys()), len(x_title)) * font_size * 1.25
+        + 87.5
     )
     max_width = svg_width - max_hostname_len - 100  # key and total placeholder
     # highest sum of counts


### PR DESCRIPTION


## What
Added some extra space in the h_bar_chart (Top 10 Hosts graph) for the legend because the hostname and the horizontal bar overlapped in some constellations.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix
<!-- Describe why are these changes necessary? -->

## References
GEA-46
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Manually tested in my development environment.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


