### PR TITLE
Change: Set Dependabot target branch and commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
 - package-ecosystem: pip
   directory: "/"
+  target-branch: "main"
   schedule:
     interval: weekly
     time: "04:00"
@@ -9,8 +10,12 @@ updates:
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+  commit-message:
+    prefix: "Deps"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: weekly
+  commit-message:
+    prefix: "Deps"


### PR DESCRIPTION
## What
Set Dependabot target branch and commit message prefix

## Why
From now on, only the main branch will be used for development and the prefix is used for generating the conventional commit release notes.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->
