### PR TITLE
Change: Use pep440 versioning scheme for release workflow

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -52,4 +52,4 @@ jobs:
           release-type: ${{ steps.release-type.outputs.release-type }}
           release-version: ${{ inputs.release-version }}
           ref: ${{ steps.release-type.outputs.release-ref }}
-          versioning-scheme: "semver"
+          versioning-scheme: "pep440"


### PR DESCRIPTION
## What
Use pep440 versioning scheme for release workflow

## Why
This is the recommended scheme for Python projects.
