### PR TITLE
Change: Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,28 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  target-branch: "main"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
-  commit-message:
-    prefix: "Deps"
+  - package-ecosystem: pip
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: weekly
-  commit-message:
-    prefix: "Deps"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "Deps"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION

## What

Group dependabot updates

## Why

Will be easier to review and merge.

## References

DEVOPS-804
