### PR TITLE
Fix: Handle missing excerpt in notes / overrides.

### DIFF
--- a/pheme/transformation/scanreport/gvmd.py
+++ b/pheme/transformation/scanreport/gvmd.py
@@ -249,7 +249,7 @@ def __create_results_per_host(report: Dict) -> List[Dict]:
         def per_note(note):
             result_notes = new_host_result.get("notes", [])
             excerpt = "0"
-            if "excerpt" in note["text"] :
+            if "excerpt" in note["text"]:
                 excerpt = note["text"]["excerpt"]
             new_note = {
                 "text": note["text"]["text"],
@@ -269,7 +269,7 @@ def __create_results_per_host(report: Dict) -> List[Dict]:
                 severity_description = "Any positive severity"
 
             excerpt = "0"
-            if "excerpt" in override["text"] :
+            if "excerpt" in override["text"]:
                 excerpt = override["text"]["excerpt"]
             new_override = {
                 "text": override["text"]["text"],

--- a/pheme/transformation/scanreport/gvmd.py
+++ b/pheme/transformation/scanreport/gvmd.py
@@ -248,9 +248,12 @@ def __create_results_per_host(report: Dict) -> List[Dict]:
 
         def per_note(note):
             result_notes = new_host_result.get("notes", [])
+            excerpt = "0"
+            if "excerpt" in note["text"] :
+                excerpt = note["text"]["excerpt"]
             new_note = {
                 "text": note["text"]["text"],
-                "text_excerpt": note["text"]["excerpt"],
+                "text_excerpt": excerpt,
             }
             result_notes.append(new_note)
 
@@ -265,9 +268,12 @@ def __create_results_per_host(report: Dict) -> List[Dict]:
             elif float(severity) > 0.0:
                 severity_description = "Any positive severity"
 
+            excerpt = "0"
+            if "excerpt" in override["text"] :
+                excerpt = override["text"]["excerpt"]
             new_override = {
                 "text": override["text"]["text"],
-                "text_excerpt": override["text"]["excerpt"],
+                "text_excerpt": excerpt,
                 "severity": severity,
                 "severity_description": severity_description,
                 "new_severity": override["new_severity"],


### PR DESCRIPTION
## What
The Vulnerability Report PDF had in special cases only a length of zero bytes (it was empty) when sent by an alert. This is no longer the case.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-408
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


