### PR TITLE
Test: Ensure test functions return None for pytest 8.4.0 compatibility

### DIFF
--- a/tests/test_format_time.py
+++ b/tests/test_format_time.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from pheme.settings import SECRET_KEY
-from tests.test_report_generation import test_http_accept
+from tests.test_report_generation import http_accept_helper
 
 
 def test_format_time_within_template():
@@ -29,6 +29,7 @@ def test_format_time_within_template():
         HTTP_X_API_KEY=SECRET_KEY,
     )
     assert response.status_code == 200
-    response = test_http_accept("text/html")
+    response = http_accept_helper("text/html")
+    assert response.status_code == 200
     html_report = response.getvalue().decode("utf-8")
     assert "Mon, Jan 01, 2018 12 AM UTC+01:00" in html_report


### PR DESCRIPTION


## What

Use a helper to avoid test functions returning non-None.

## Why

This is needed for pytest 8.4.0 compatibility. Tests returning non-None are failing in https://github.com/greenbone/pheme/pull/978.

See pytest [changelog](https://github.com/pytest-dev/pytest/releases)

## References
GEA-1110


