### PR TITLE
Upload container images to ghcr.io

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,7 +24,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: greenbone/pheme
+          images: ghcr.io/${{ github.repository }}
           labels: |
             org.opencontainers.image.vendor=Greenbone
             org.opencontainers.image.base.name=debian/bullseye-slim
@@ -48,8 +48,9 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ secrets.GREENBONE_BOT }}
+          password: ${{ secrets.GREENBONE_BOT_PACKAGES_WRITE_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION


## What

Upload container images to ghcr.io

## Why

We don't use docker.io anymore.

