### PR TITLE
Group all actions from Github Inc.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
       github-actions:
         patterns:
           - "actions/*"
+          - "github/*"
     ignore:
       - dependency-name: "greenbone/actions"
         update-types:


### PR DESCRIPTION


## What
Group all actions from Github Inc.

## Why

GitHub Inc. publishes actions under the github.com/actions and github.com/github organizations.