### PR TITLE
Change back to using greenbone bot token again

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,5 +10,5 @@ permissions:
 jobs:
   auto-merge:
     uses: greenbone/workflows/.github/workflows/auto-merge.yml@main
-    with:
-      github-token: ${{ github.token }}
+    secrets:
+      GREENBONE_BOT_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION

## What

Change back to using greenbone bot token again

## Why

The branch protection or in future the rulesets need to be satisfied for being able to set the auto-merge status. The bot user will get a bypass so it will be able to set it.

